### PR TITLE
(cloud-1747) Fixing docker UCP uninstall

### DIFF
--- a/manifests/ucp.pp
+++ b/manifests/ucp.pp
@@ -173,7 +173,7 @@ class docker_ddc::ucp (
       extra_parameters          => any2array($extra_parameters),
     })
     exec { 'Uninstall Docker Universal Control Plane':
-      command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock --name ucp docker/ucp uninstall ${uninstall_flags}", # lint:ignore:140chars
+      command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock --name ucp docker/ucp uninstall-ucp ${uninstall_flags}", # lint:ignore:140chars
       onlyif  => $join_unless,
     }
   } else {


### PR DESCRIPTION
This PR updates the flag being used to uninstall UCP. Currently uninstall is being passed but the uninstall command has been changed in ucp to uninstall-ucp. I have confirmed that UCP is now being uninstalled successfully.  